### PR TITLE
Add python3 compatibility

### DIFF
--- a/mpltex/styles.py
+++ b/mpltex/styles.py
@@ -52,7 +52,7 @@ def linestyle_generator(colors=_colors, lines=_lines,
     Usage::
 
       linestyles = linestyle_generator()
-      linestyle = linestyles.next()
+      linestyle = linestyles.__next__()
 
     Note that all inputs should be iterable objects.
     To exclude one style, just pass empty list or ``None`` to the corresponding argument.
@@ -98,9 +98,9 @@ def linestyle_generator(colors=_colors, lines=_lines,
 
     while True:
         if not is_nothing:
-            color = color_cycle.next()
-            linestyle = line_cycle.next()
-            marker, hollow = marker_cycle.next()
+            color = color_cycle.__next__()
+            linestyle = line_cycle.__next__()
+            marker, hollow = marker_cycle.__next__()
             if hollow is None:  # only filled markers
                 mew = 1
                 mec = color


### PR DESCRIPTION
Using `__next__()` iterator Python3 compatibility is added.
Replaces #1.